### PR TITLE
Apply Terraform module standards and linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # Deploy and IPSec VPN and Router on Packet Baremetal
-This repo will allow you to deploy a VyOS router onto a baremetal node in Packet. It will then generate a config file to setup an IPSec tunnel with a Cisco 1000v from Equinix's ***Network Edge***. As of now there is no way to fully automate the configuration of the router (That I've figured out). So we'll be doing a few steps by hand.
-## Install Terraform 
-Terraform is just a single binary.  Visit their [download page](https://www.terraform.io/downloads.html), choose your operating system, make the binary executable, and move it into your path. 
- 
-Here is an example for **macOS**: 
-```bash 
-curl -LO https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_darwin_amd64.zip 
-unzip terraform_0.12.18_darwin_amd64.zip 
-chmod +x terraform 
-sudo mv terraform /usr/local/bin/ 
-``` 
- 
+
+This repo will allow you to deploy a [VyOS router](https://www.vyos.io/products/#vyos-router) onto a [baremetal node in Packet](https://www.packet.com/cloud/). It will then generate a config file to setup an IPSec tunnel with a Cisco 1000v from [Equinix's ***Network Edge***](https://www.equinix.com/services/edge-services/network-edge/). As of now there is no way to fully automate the configuration of the router (That I've figured out). So we'll be doing a few steps by hand.
+
+## Install Terraform
+
+Terraform is just a single binary.  Visit their [download page](https://www.terraform.io/downloads.html), choose your operating system, make the binary executable, and move it into your path.
+
+Here is an example for **macOS**:
+
+```bash
+curl -LO https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_darwin_amd64.zip
+unzip terraform_0.12.18_darwin_amd64.zip
+chmod +x terraform
+sudo mv terraform /usr/local/bin/
+```
+
 ## Download this project
+
 To download this project, run the following command:
 
 ```bash
@@ -19,24 +24,31 @@ git clone https://github.com/packet-labs/packet-router.git
 cd packet-router
 ```
 
-## Initialize Terraform 
-Terraform uses modules to deploy infrastructure. In order to initialize the modules your simply run: `terraform init`. This should download modules into a hidden directory `.terraform` 
- 
-## Modify your variables 
+## Initialize Terraform
+
+Terraform uses modules to deploy infrastructure. In order to initialize the modules your simply run: `terraform init`. This should download modules into a hidden directory `.terraform`
+
+## Modify your variables
+
 You will need to set three variables at a minimum and there are a lot more you may wish to modify in `variables.tf`
-```bash 
-cat <<EOF >terraform.tfvars 
-auth_token = "cefa5c94-e8ee-4577-bff8-1d1edca93ed8" 
-project_id = "42259e34-d300-48b3-b3e1-d5165cd14169" 
+
+```bash
+cat <<EOF >terraform.tfvars
+auth_token = "cefa5c94-e8ee-4577-bff8-1d1edca93ed8"
+project_id = "42259e34-d300-48b3-b3e1-d5165cd14169"
 ipsec_peer_public_ip = "192.168.2.2"
-EOF 
-``` 
+EOF
+```
+
 ## Deploy terraform template
+
 ```bash
 terraform apply --auto-approve
 ```
+
 Once this is complete you should get output similar to this:
-```
+
+```console
 Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
 
 Outputs:
@@ -51,6 +63,7 @@ VyOS_Config_File = ./vyos.conf
 ```
 
 ## Install VyOS to disk
+
 What we want to do here is install VyOS to the local disk on the system and set a password.
 
 There is no automated way to do this yet (I have been informed there is, it uses cloud-init, I'll look into this), so you need too SSH into the box and run the command `install image` and follow the prompts. Find the **SSH** command in the terraform outputs.
@@ -73,11 +86,10 @@ you have already setup your partitions, you may skip this step
 Partition (Auto/Parted/Skip) [Auto]: <b>Auto</b>
 
 I found the following drives on your system:
- sda	480103MB
- sdb	480103MB
- sdc	240057MB
- sdd	240057MB
-
+ sda 480103MB
+ sdb 480103MB
+ sdc 240057MB
+ sdd 240057MB
 
 Install the image on? [sda]:<b>sdc</b>
 
@@ -110,11 +122,10 @@ Enter password for user 'vyos':
 Retype password for user 'vyos':
 I need to install the GRUB boot loader.
 I found the following drives on your system:
- sda	480103MB
- sdb	480103MB
- sdc	240057MB
- sdd	240057MB
-
+ sda 480103MB
+ sdb 480103MB
+ sdc 240057MB
+ sdd 240057MB
 
 Which drive should GRUB modify the boot partition on? [sda]:<b>sdc</b>
 
@@ -123,6 +134,7 @@ Done!
 </pre>
 
 ## Set a VyOS password
+
 Wait... Didn't VyOS just ask me to set a password for the **vyos** two minutes ago? Yep! I'm not sure what that does... But I had to set the password via config mode myself. (I even tried a reboot thinking maybe this only takes effect after the server boots from the newly installed disk... No dice!) Here we go:
 <pre>
 vyos@vyos:~$ <b>conf</b>
@@ -141,6 +153,7 @@ vyos@vyos:~$
 </pre>
 
 ## Disable Cloud-Init
+
 For some reason cloud-init gets in our way as we move forward. So we need to get rid of cloud-init to proceed.
 <pre>
 vyos@vyos:~$ <b>sudo apt remove cloud-init -y</b>
@@ -148,7 +161,8 @@ vyos@vyos:~$ <b>sudo rm -f /etc/network/interfaces.d/50-cloud-init.cfg</b>
 </pre>
 
 ## Apply VyOS Config
-Ok so I had some issues here geting the config working properly via SSH. I think we get disconnected when we change the interface config away from DHCP and to static. So I had to apply the config via the SOS console.
+
+Ok so I had some issues here getting the config working properly via SSH. I think we get disconnected when we change the interface config away from DHCP and to static. So I had to apply the config via the SOS console.
 
 Find the **Out_of_Band_Console** command in the Terraform output. Also you set the *vyos* users password in a previous step, you'll need that to login via the console.
 
@@ -158,5 +172,4 @@ Once you've logged in and and are at the command line you'll need to go into ***
 
 There are a few places where you will see **### STOP HERE ###**. Read the comments in the file and do as instructed.
 
-## Done! Go setup the other side of the VPN!
-
+## Done! Go setup the other side of the VPN

--- a/main.tf
+++ b/main.tf
@@ -78,37 +78,3 @@ resource "local_file" "vyos_config" {
     file_permission = "0644"
 }
 
-output "SSH" {
-  value       = "ssh vyos@${packet_device.router.network.0.address}"
-  description = "Command to SSH into the VyOS Router"
-}
-
-output "Out_of_Band_Console" {
-  value       = "ssh ${packet_device.router.id}@sos.${lower(var.facility)}.packet.net"
-  description = "Command to SSH into the Serial over Lan Console of the VyOS Router"
-}
-
-output "VyOS_Config_File" {
-  value       = "${path.module}/vyos.conf"
-  description = "The Name of the VyOS config file"
-}
-
-output "BGP_Password" {
-  value       = random_string.bgp_password.result
-  description = "The BGP password for peering"
-}
-
-output "IPSec_Pre_Shared_Key" {
-  value       = random_string.ipsec_psk.result
-  description = "IPSec pre shared key for authentication."
-}
-
-output "IPSec_Public_IP" {
-  value       = packet_device.router.network.0.address
-  description = "Public IP for IPSec VPN"
-}
-
-output "IPSec_Private_IP_CIDR" {
-  value       = format("%s/%s", cidrhost(var.ipsec_private_cidr, 2), split("/", var.ipsec_private_cidr)[1])
-  description = "Private IP space inside the ipsec tunnel to do BGP peering."
-}

--- a/main.tf
+++ b/main.tf
@@ -1,80 +1,80 @@
 provider "packet" {
-    auth_token = var.auth_token
+  auth_token = var.auth_token
 }
 
 resource "packet_vlan" "private_vlan" {
-    facility    = var.facility
-    project_id  = var.project_id
-    description = "Private Network"
+  facility    = var.facility
+  project_id  = var.project_id
+  description = "Private Network"
 }
 
 resource "random_string" "bgp_password" {
-    length = 18
-    min_upper = 1 
-    min_lower = 1 
-    min_numeric = 1 
-    special = false
+  length      = 18
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+  special     = false
 }
 
 resource "random_string" "ipsec_psk" {
-  length = 20
-  min_upper = 2
-  min_lower = 2
+  length      = 20
+  min_upper   = 2
+  min_lower   = 2
   min_numeric = 2
-  special = false
+  special     = false
 }
 
 resource "packet_device" "router" {
-    hostname         = var.hostname
-    plan             = var.plan
-    facilities       = [var.facility]
-    operating_system = var.operating_system
-    billing_cycle    = var.billing_cycle
-    project_id       = var.project_id
-    ipxe_script_url  = var.ipxe_script_url
-    always_pxe       = var.always_pxe
-    network_type     = "hybrid"
+  hostname         = var.hostname
+  plan             = var.plan
+  facilities       = [var.facility]
+  operating_system = var.operating_system
+  billing_cycle    = var.billing_cycle
+  project_id       = var.project_id
+  ipxe_script_url  = var.ipxe_script_url
+  always_pxe       = var.always_pxe
+  network_type     = "hybrid"
 }
 
 resource "packet_port_vlan_attachment" "router_vlan_attach" {
-    device_id = packet_device.router.id
-    port_name = "eth1"
-    vlan_vnid = packet_vlan.private_vlan.vxlan
+  device_id = packet_device.router.id
+  port_name = "eth1"
+  vlan_vnid = packet_vlan.private_vlan.vxlan
 }
 
 data "template_file" "vyos_config" {
-    template = file("templates/vyos_config.conf")
-    vars = {
-        bgp_local_asn = var.bgp_local_asn
-        bgp_neighbor_asn = var.bgp_neighbor_asn
-        bgp_password = random_string.bgp_password.result
-        hostname = var.hostname
-        ipsec_psk = random_string.ipsec_psk.result
-        ipsec_peer_public_ip = var.ipsec_peer_public_ip
-        ipsec_peer_private_ip = cidrhost(var.ipsec_private_cidr, 2)
-        ipsec_private_ip_cidr = format("%s/%s", cidrhost(var.ipsec_private_cidr, 2), split("/", var.ipsec_private_cidr)[1])
-        neighbor_short_name = var.neighbor_short_name
-        private_net_cidr = var.private_net_cidr
-        private_net_dhcp_start_ip = cidrhost(var.private_net_cidr, 2)
-        private_net_dhcp_stop_ip = cidrhost(var.private_net_cidr, -2)
-        private_net_gateway_ip_cidr = format("%s/%s", cidrhost(var.private_net_cidr, 1), split("/", var.private_net_cidr)[1])
-        private_net_gateway_ip = cidrhost(var.private_net_cidr, 2)
-        public_dns_1_ip = var.public_dns_1_ip
-        public_dns_2_ip = var.public_dns_2_ip
-        router_ipv6_gateway_ip = packet_device.router.network.1.gateway
-        router_ipv6_ip_cidr = format("%s/%s", packet_device.router.network.1.address, packet_device.router.network.1.cidr)
-        router_private_cidr = format("%s/%s", cidrhost(format("%s/%s", packet_device.router.network.2.address, packet_device.router.network.2.cidr), 0), packet_device.router.network.2.cidr)
-        router_private_gateway_ip = packet_device.router.network.2.gateway
-        router_private_ip_cidr = format("%s/%s", packet_device.router.network.2.address, packet_device.router.network.2.cidr)
-        router_public_gateway_ip = packet_device.router.network.0.gateway
-        router_public_ip_cidr = format("%s/%s", packet_device.router.network.0.address, packet_device.router.network.0.cidr)
-        router_public_ip = packet_device.router.network.0.address
-    }
+  template = file("templates/vyos_config.conf")
+  vars = {
+    bgp_local_asn               = var.bgp_local_asn
+    bgp_neighbor_asn            = var.bgp_neighbor_asn
+    bgp_password                = random_string.bgp_password.result
+    hostname                    = var.hostname
+    ipsec_psk                   = random_string.ipsec_psk.result
+    ipsec_peer_public_ip        = var.ipsec_peer_public_ip
+    ipsec_peer_private_ip       = cidrhost(var.ipsec_private_cidr, 2)
+    ipsec_private_ip_cidr       = format("%s/%s", cidrhost(var.ipsec_private_cidr, 2), split("/", var.ipsec_private_cidr)[1])
+    neighbor_short_name         = var.neighbor_short_name
+    private_net_cidr            = var.private_net_cidr
+    private_net_dhcp_start_ip   = cidrhost(var.private_net_cidr, 2)
+    private_net_dhcp_stop_ip    = cidrhost(var.private_net_cidr, -2)
+    private_net_gateway_ip_cidr = format("%s/%s", cidrhost(var.private_net_cidr, 1), split("/", var.private_net_cidr)[1])
+    private_net_gateway_ip      = cidrhost(var.private_net_cidr, 2)
+    public_dns_1_ip             = var.public_dns_1_ip
+    public_dns_2_ip             = var.public_dns_2_ip
+    router_ipv6_gateway_ip      = packet_device.router.network.1.gateway
+    router_ipv6_ip_cidr         = format("%s/%s", packet_device.router.network.1.address, packet_device.router.network.1.cidr)
+    router_private_cidr         = format("%s/%s", cidrhost(format("%s/%s", packet_device.router.network.2.address, packet_device.router.network.2.cidr), 0), packet_device.router.network.2.cidr)
+    router_private_gateway_ip   = packet_device.router.network.2.gateway
+    router_private_ip_cidr      = format("%s/%s", packet_device.router.network.2.address, packet_device.router.network.2.cidr)
+    router_public_gateway_ip    = packet_device.router.network.0.gateway
+    router_public_ip_cidr       = format("%s/%s", packet_device.router.network.0.address, packet_device.router.network.0.cidr)
+    router_public_ip            = packet_device.router.network.0.address
+  }
 }
 
 resource "local_file" "vyos_config" {
-    content     = data.template_file.vyos_config.rendered
-    filename = "${path.module}/vyos.conf"
-    file_permission = "0644"
+  content         = data.template_file.vyos_config.rendered
+  filename        = "${path.module}/vyos.conf"
+  file_permission = "0644"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,34 @@
+output "SSH" {
+  value       = "ssh vyos@${packet_device.router.network.0.address}"
+  description = "Command to SSH into the VyOS Router"
+}
+
+output "Out_of_Band_Console" {
+  value       = "ssh ${packet_device.router.id}@sos.${lower(var.facility)}.packet.net"
+  description = "Command to SSH into the Serial over Lan Console of the VyOS Router"
+}
+
+output "VyOS_Config_File" {
+  value       = "${path.module}/vyos.conf"
+  description = "The Name of the VyOS config file"
+}
+
+output "BGP_Password" {
+  value       = random_string.bgp_password.result
+  description = "The BGP password for peering"
+}
+
+output "IPSec_Pre_Shared_Key" {
+  value       = random_string.ipsec_psk.result
+  description = "IPSec pre shared key for authentication."
+}
+
+output "IPSec_Public_IP" {
+  value       = packet_device.router.network.0.address
+  description = "Public IP for IPSec VPN"
+}
+
+output "IPSec_Private_IP_CIDR" {
+  value       = format("%s/%s", cidrhost(var.ipsec_private_cidr, 2), split("/", var.ipsec_private_cidr)[1])
+  description = "Private IP space inside the ipsec tunnel to do BGP peering."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "auth_token" {
-    type = string
-    description = "Packet API Key"
+  type        = string
+  description = "Packet API Key"
 }
 
 variable "project_id" {
-    type = string
-    description = "The project id to deploy into"
+  type        = string
+  description = "The project id to deploy into"
 }
 
 variable "ipsec_peer_public_ip" {
@@ -32,9 +32,9 @@ variable "plan" {
 }
 
 variable "operating_system" {
-    type = string
-    description = "The Operating system of the node (This needs to be (custom_ipxe)"
-    default = "custom_ipxe"
+  type        = string
+  description = "The Operating system of the node (This needs to be (custom_ipxe)"
+  default     = "custom_ipxe"
 }
 
 variable "ipxe_script_url" {
@@ -45,13 +45,13 @@ variable "ipxe_script_url" {
 
 variable "always_pxe" {
   type        = bool
-  default     = false 
+  default     = false
   description = "Wheather to always boot via iPXE or not."
 }
 
 variable "billing_cycle" {
-    description = "How the node will be billed (Not usually changed)"
-    default = "hourly"
+  description = "How the node will be billed (Not usually changed)"
+  default     = "hourly"
 }
 
 variable "bgp_local_asn" {


### PR DESCRIPTION
Terraform users can benefit from configs created with modular reuse, with commands such as `terraform init --from-module=packet-labs/packet-router packet-router`.  The delta between this module today and a publish-ready module is very small.

This PR prepares this module for use in the [Terraform registry](https://www.terraform.io/docs/registry/modules/publish.html) by applying some of the practices advised (or required) for modules, here: https://www.terraform.io/docs/modules/index.html#standard-module-structure

Additionally, [`terraform fmt`](https://www.terraform.io/docs/commands/fmt.html) was applied along with automated [Markdown linter](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#rules) [fixing](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).

An extra requirement for publishing this module will be to [rename the Git repo](https://www.terraform.io/docs/registry/modules/publish.html#requirements) from "packet-router" to "terraform-packet-router".
