### PR TITLE
Update main.tf with new packet_device_network_type resource for mixed networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ vyos@vyos:~$ <b>sudo apt remove cloud-init -y</b>
 vyos@vyos:~$ <b>sudo rm -f /etc/network/interfaces.d/50-cloud-init.cfg</b>
 </pre>
 
+##
+After installing VyOS to disk, the Bare Metal Server should be rebooted before applying production configurations.
+
+<pre>
+vyos@vyos:~$ reboot
+Are you sure you want to reboot this system? [y/N]
+</pre>
+
 ## Apply VyOS Config
 
 Ok so I had some issues here getting the config working properly via SSH. I think we get disconnected when we change the interface config away from DHCP and to static. So I had to apply the config via the SOS console.

--- a/main.tf
+++ b/main.tf
@@ -33,13 +33,18 @@ resource "packet_device" "router" {
   project_id       = var.project_id
   ipxe_script_url  = var.ipxe_script_url
   always_pxe       = var.always_pxe
-  network_type     = "hybrid"
+}
+
+resource "packet_device_network_type" "router" {
+  device_id = packet_device.router.id
+  type = "hybrid"
 }
 
 resource "packet_port_vlan_attachment" "router_vlan_attach" {
   device_id = packet_device.router.id
   port_name = "eth1"
   vlan_vnid = packet_vlan.private_vlan.vxlan
+  depends_on = [packet_device_network_type.router]
 }
 
 data "template_file" "vyos_config" {


### PR DESCRIPTION
The `3.0` release of the Packet Provider from Terraform [introduced intentional breaking changes](https://github.com/terraform-providers/terraform-provider-packet/commit/343658b95efcae2a7d86461634a835f0c387195e) for Packet instance resource definitions with mixed-mode networking.

This updates this `main.tf` to use the new [preferred resource](https://www.terraform.io/docs/providers/packet/r/device_network_type.html) type for mixed networking and places a `depends_on` to ensure healthy ordering.

It also quickly closes @c0dyhi11 's issue #3 for [rebooting after install](https://github.com/packet-labs/packet-router/issues/3) while were at it. 