### PR TITLE
WIP: refactor provisioning to use cloud-init

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,33 @@ resource "random_string" "ipsec_psk" {
   special = false
 }
 
+resource "random_string" "login_password" {
+  length = 20
+  min_upper = 2
+  min_lower = 2
+  min_numeric = 2
+  special = false
+}
+
+resource "tls_private_key" "ssh_key_pair" {
+    algorithm = "RSA"
+    rsa_bits = 4096
+}
+
+resource "packet_ssh_key" "ssh_pub_key" {
+    name = "VyOS SSH Key"
+    public_key = chomp(tls_private_key.ssh_key_pair.public_key_openssh)
+}
+
+
+data "template_file" "user_data" {
+    template = file("templates/user_data.conf")
+}
+
 resource "packet_device" "router" {
+    depends_on = [
+        packet_ssh_key.ssh_pub_key
+    ]
     hostname         = var.hostname
     plan             = var.plan
     facilities       = [var.facility]
@@ -34,6 +60,7 @@ resource "packet_device" "router" {
     ipxe_script_url  = var.ipxe_script_url
     always_pxe       = var.always_pxe
     network_type     = "hybrid"
+    user_data        = data.template_file.user_data.rendered
 }
 
 resource "packet_port_vlan_attachment" "router_vlan_attach" {
@@ -43,7 +70,7 @@ resource "packet_port_vlan_attachment" "router_vlan_attach" {
 }
 
 data "template_file" "vyos_config" {
-    template = file("templates/vyos_config.conf")
+    template = file("templates/config.boot")
     vars = {
         bgp_local_asn = var.bgp_local_asn
         bgp_neighbor_asn = var.bgp_neighbor_asn
@@ -53,12 +80,13 @@ data "template_file" "vyos_config" {
         ipsec_peer_public_ip = var.ipsec_peer_public_ip
         ipsec_peer_private_ip = cidrhost(var.ipsec_private_cidr, 2)
         ipsec_private_ip_cidr = format("%s/%s", cidrhost(var.ipsec_private_cidr, 2), split("/", var.ipsec_private_cidr)[1])
+        login_password = random_string.login_password.result
         neighbor_short_name = var.neighbor_short_name
         private_net_cidr = var.private_net_cidr
         private_net_dhcp_start_ip = cidrhost(var.private_net_cidr, 2)
         private_net_dhcp_stop_ip = cidrhost(var.private_net_cidr, -2)
         private_net_gateway_ip_cidr = format("%s/%s", cidrhost(var.private_net_cidr, 1), split("/", var.private_net_cidr)[1])
-        private_net_gateway_ip = cidrhost(var.private_net_cidr, 2)
+        private_net_gateway_ip = cidrhost(var.private_net_cidr, 1)
         public_dns_1_ip = var.public_dns_1_ip
         public_dns_2_ip = var.public_dns_2_ip
         router_ipv6_gateway_ip = packet_device.router.network.1.gateway
@@ -72,10 +100,29 @@ data "template_file" "vyos_config" {
     }
 }
 
-resource "local_file" "vyos_config" {
-    content     = data.template_file.vyos_config.rendered
-    filename = "${path.module}/vyos.conf"
-    file_permission = "0644"
+resource "null_resource" "configure_vyos"{
+    connection {
+        type = "ssh"
+        user = "vyos"
+        private_key = chomp(tls_private_key.ssh_key_pair.private_key_pem)
+        host = packet_device.router.access_public_ipv4
+    }
+
+    provisioner "file" {
+        content = data.template_file.vyos_config.rendered
+        destination = "/tmp/config.boot"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "sudo mv /tmp/config.boot /config/config.boot",
+            "sudo chmod 775 /config/config.boot",
+            "sudo chown root:vyattacfg /config/config.boot",
+            "#sudo sudo apt remove cloud-init -y",
+            "#sudo rm -f /etc/network/interfaces.d/50-cloud-init.cfg",
+            "sudo /sbin/shutdown -r 1"
+        ]
+    }
 }
 
 output "SSH" {
@@ -86,11 +133,6 @@ output "SSH" {
 output "Out_of_Band_Console" {
   value       = "ssh ${packet_device.router.id}@sos.${lower(var.facility)}.packet.net"
   description = "Command to SSH into the Serial over Lan Console of the VyOS Router"
-}
-
-output "VyOS_Config_File" {
-  value       = "${path.module}/vyos.conf"
-  description = "The Name of the VyOS config file"
 }
 
 output "BGP_Password" {
@@ -112,3 +154,4 @@ output "IPSec_Private_IP_CIDR" {
   value       = format("%s/%s", cidrhost(var.ipsec_private_cidr, 2), split("/", var.ipsec_private_cidr)[1])
   description = "Private IP space inside the ipsec tunnel to do BGP peering."
 }
+

--- a/templates/config.boot
+++ b/templates/config.boot
@@ -1,0 +1,266 @@
+firewall {
+    all-ping enable
+    broadcast-ping disable
+    config-trap disable
+    ipv6-receive-redirects disable
+    ipv6-src-route disable
+    ip-src-route disable
+    log-martians enable
+    name OUTSIDE-IN {
+        default-action drop
+        rule 10 {
+            action accept
+            state {
+                established enable
+                related enable
+            }
+        }
+    }
+    receive-redirects disable
+    send-redirects enable
+    source-validation disable
+    syn-cookies enable
+    twa-hazards-protection disable
+}
+interfaces {
+    bonding bond0 {
+        address ${router_public_ip_cidr}
+        address ${router_private_ip_cidr}
+        address ${router_ipv6_ip_cidr}
+        description "Bond towards Packet"
+        firewall {
+            in {
+                name OUTSIDE-IN
+            }
+        }
+        hash-policy layer2
+        mode 802.3ad
+    }
+    ethernet eth0 {
+        bond-group bond0
+        description "member of bond0"
+        duplex auto
+        smp-affinity auto
+        speed auto
+    }
+    ethernet eth1 {
+        address ${private_net_gateway_ip_cidr}
+        description "Private Net"
+        duplex auto
+        smp-affinity auto
+        speed auto
+    }
+    loopback lo {
+    }
+    vti vti1 {
+        address ${ipsec_private_ip_cidr}
+    }
+}
+nat {
+    source {
+        rule 100 {
+            outbound-interface bond0
+            source {
+                address ${private_net_cidr}
+            }
+            translation {
+                address masquerade
+            }
+        }
+    }
+}
+policy {
+    prefix-list TO-${neighbor_short_name} {
+        rule 10 {
+            action permit
+            prefix ${private_net_cidr}
+        }
+    }
+    route-map ${neighbor_short_name}-OUT {
+        rule 10 {
+            action permit
+            match {
+                ip {
+                    address {
+                        prefix-list TO-${neighbor_short_name}
+                    }
+                }
+            }
+        }
+        rule 20 {
+            action deny
+        }
+    }
+}
+protocols {
+    bgp ${bgp_local_asn} {
+        address-family {
+            ipv4-unicast {
+                network ${private_net_cidr} {
+                }
+            }
+        }
+        neighbor ${ipsec_peer_private_ip} {
+            address-family {
+                ipv4-unicast {
+                    route-map {
+                        export ${neighbor_short_name}-OUT
+                    }
+                    soft-reconfiguration {
+                        inbound
+                    }
+                }
+            }
+            password ${bgp_password}
+            remote-as ${bgp_neighbor_asn}
+            timers {
+                holdtime 30
+                keepalive 10
+            }
+        }
+        parameters {
+            log-neighbor-changes
+        }
+        timers {
+            holdtime 4
+            keepalive 2
+        }
+    }
+    static {
+        route 0.0.0.0/0 {
+            next-hop ${router_public_gateway_ip} {
+            }
+        }
+        route ${router_private_cidr} {
+            next-hop ${router_private_gateway_ip} {
+            }
+        }
+        route6 ::/0 {
+            next-hop ${router_ipv6_gateway_ip} {
+            }
+        }
+    }
+}
+service {
+    dhcp-server {
+        shared-network-name lan-dhcp {
+            authoritative
+            subnet ${private_net_cidr} {
+                default-router ${private_net_gateway_ip}
+                dns-server ${private_net_gateway_ip}
+                lease 86400
+                range 0 {
+                    start ${private_net_dhcp_start_ip}
+                    stop ${private_net_dhcp_stop_ip}
+                }
+            }
+        }
+    }
+    dns {
+        forwarding {
+            listen-address ${private_net_gateway_ip}
+            name-server ${public_dns_1_ip}
+            name-server ${public_dns_2_ip}
+        }
+    }
+    ssh {
+        client-keepalive-interval 180
+        port 22
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 9600
+        }
+        device ttyS1 {
+            speed 115200
+        }
+    }
+    host-name ${hostname}
+    login {
+        user vyos {
+            authentication {
+                plaintext-password "${login_password}"
+            }
+            level admin
+        }
+    }
+    name-server ${public_dns_1_ip}
+    name-server ${public_dns_2_ip}
+    ntp {
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+    time-zone UTC
+}
+vpn {
+    ipsec {
+        esp-group ${neighbor_short_name}-S2S-IPSEC {
+            compression disable
+            lifetime 3600
+            mode tunnel
+            pfs dh-group2
+            proposal 1 {
+                encryption aes128
+                hash sha1
+            }
+        }
+        ike-group ${neighbor_short_name}-S2S-IKE {
+            dead-peer-detection {
+                action restart
+                interval 15
+                timeout 30
+            }
+            ikev2-reauth no
+            key-exchange ikev1
+            lifetime 3600
+            proposal 1 {
+                dh-group 2
+                encryption aes128
+                hash md5
+            }
+        }
+        ipsec-interfaces {
+            interface bond0
+        }
+        site-to-site {
+            peer ${ipsec_peer_public_ip} {
+                authentication {
+                    mode pre-shared-secret
+                    pre-shared-secret ${ipsec_psk}
+                }
+                connection-type initiate
+                ike-group ${neighbor_short_name}-S2S-IKE
+                ikev2-reauth inherit
+                local-address ${router_public_ip}
+                vti {
+                    bind vti1
+                    esp-group ${neighbor_short_name}-S2S-IPSEC
+                }
+            }
+        }
+    }
+}
+
+
+/* Warning: Do not remove the following line. */
+/* === vyatta-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack-sync@1:conntrack@1:dhcp-relay@2:dhcp-server@5:firewall@5:ipsec@5:l2tp@1:mdns@1:nat@4:ntp@1:pptp@1:qos@1:quagga@3:ssh@1:system@9:vrrp@2:vyos-accel-ppp@1:wanloadbalance@3:webgui@1:webproxy@1:webproxy@2:zone-policy@1" === */
+/* Release version: 1.2.2 */

--- a/templates/user_data.conf
+++ b/templates/user_data.conf
@@ -1,0 +1,3 @@
+#cloud-config
+install_drive: auto
+cloud_init_disable: true


### PR DESCRIPTION
(This is an older branch from @c0dyhi11 to use cloud-init to simplify provisioning.)
(vyos has documentation on cloud-init here: https://docs.vyos.io/en/latest/automation/cloud-init.html. vyos appears to have a debian base so common cloud-init kernel parameters should be available for defining the metadata URL `ci.ds=ec2;metadata_urls=https://metadata.platformequinix.com/metadata,http://metadata.packet.net/`)